### PR TITLE
Wrap Ruby's Timeout module around the RestClient call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ pkg
 
 ## PROJECT::SPECIFIC
 spec/api.yml
+
+## RVM
+.rvmrc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,8 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    addressable (2.2.6)
+    crack (0.3.1)
     diff-lcs (1.1.2)
     json (1.5.3)
     mime-types (1.16)
@@ -21,6 +23,9 @@ GEM
     rspec-expectations (2.6.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.6.0)
+    webmock (1.7.10)
+      addressable (~> 2.2, > 2.2.5)
+      crack (>= 0.1.7)
 
 PLATFORMS
   ruby
@@ -28,3 +33,4 @@ PLATFORMS
 DEPENDENCIES
   geo_ip!
   rspec (~> 2.5)
+  webmock (~> 1.7.10)

--- a/geo_ip.gemspec
+++ b/geo_ip.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'json', '~> 1.4'
   s.add_dependency 'rest-client', '~> 1.6.1'
   s.add_development_dependency 'rspec', '~> 2.5'
+  s.add_development_dependency 'webmock', '~> 1.7.10'
 end

--- a/spec/geo_ip_spec.rb
+++ b/spec/geo_ip_spec.rb
@@ -2,8 +2,27 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 IP_GOOGLE_US = '209.85.227.104'
 IP_PRIVATE = '10.0.0.1'
 IP_LOCAL = '127.0.0.1'
+# Use WebMock as default to speed up tests and for local development without a connection
+# Change this to false to have tests make real http requests if you want. Perhaps to check whether IpInfoDb's API has changed
+# However, you may need to increase the GeoIp.fallback_timeout variable if Timeout exceptions occur when tests are run
+USE_WEBMOCK = true
 
 describe 'GeoIp' do
+  before :all do
+    unless USE_WEBMOCK
+      puts "Running tests WITHOUT WebMock. You will need an internet connection. You may need to increase the GeoIp.fallback_timeout amount."
+      WebMock.disable!
+    end
+  end
+
+  def stub_geolocation(ip, options = {}, &block)
+    if USE_WEBMOCK
+      stub_request(:get, GeoIp.lookup_url(ip, options)).
+             with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate'}).
+             to_return(:status => 200, :body => yield, :headers => {})
+    end
+  end
+
   before :each do
     api_config = YAML.load_file(File.dirname(__FILE__) + '/api.yml')
     GeoIp.api_key = api_config['key']
@@ -23,6 +42,22 @@ describe 'GeoIp' do
 
   context 'city' do
     it 'should return the correct city for a public ip address' do
+      stub_geolocation(IP_GOOGLE_US) do
+%[{
+              "statusCode" : "OK",
+              "statusMessage" : "",
+              "ipAddress" : "209.85.227.104",
+              "countryCode" : "US",
+              "countryName" : "UNITED STATES",
+              "regionName" : "CALIFORNIA",
+              "cityName" : "MONTEREY PARK",
+              "zipCode" : "91754",
+              "latitude" : "34.0505",
+              "longitude" : "-118.13",
+              "timeZone" : "-08:00"
+}]
+      end
+
       geolocation = GeoIp.geolocation(IP_GOOGLE_US)
       geolocation[:country_code].should == 'US'
       geolocation[:country_name].should == 'UNITED STATES'
@@ -30,6 +65,22 @@ describe 'GeoIp' do
     end
 
     it 'should return nothing city for a private ip address' do
+      stub_geolocation(IP_PRIVATE) do
+%[{
+              "statusCode" : "OK",
+              "statusMessage" : "",
+              "ipAddress" : "10.0.0.1",
+              "countryCode" : "-",
+              "countryName" : "-",
+              "regionName" : "-",
+              "cityName" : "-",
+              "zipCode" : "-",
+              "latitude" : "0",
+              "longitude" : "0",
+              "timeZone" : "-"
+}]
+      end
+
       geolocation = GeoIp.geolocation(IP_PRIVATE)
       geolocation[:country_code].should == '-'
       geolocation[:country_name].should == '-'
@@ -37,6 +88,22 @@ describe 'GeoIp' do
     end
 
     it 'should return nothing for localhost ip address' do
+      stub_geolocation(IP_LOCAL) do
+%[{
+	"statusCode" : "OK",
+	"statusMessage" : "",
+	"ipAddress" : "127.0.0.1",
+	"countryCode" : "-",
+	"countryName" : "-",
+	"regionName" : "-",
+	"cityName" : "-",
+	"zipCode" : "-",
+	"latitude" : "0",
+	"longitude" : "0",
+	"timeZone" : "-"
+}]
+      end
+
       geolocation = GeoIp.geolocation(IP_LOCAL)
       geolocation[:country_code].should == '-'
       geolocation[:country_name].should == '-'
@@ -44,6 +111,22 @@ describe 'GeoIp' do
     end
 
     it 'should return the correct city for a public ip address when explicitly requiring it' do
+      stub_geolocation(IP_GOOGLE_US) do
+%[{
+	"statusCode" : "OK",
+	"statusMessage" : "",
+	"ipAddress" : "209.85.227.104",
+	"countryCode" : "US",
+	"countryName" : "UNITED STATES",
+	"regionName" : "CALIFORNIA",
+	"cityName" : "MONTEREY PARK",
+	"zipCode" : "91754",
+	"latitude" : "34.0505",
+	"longitude" : "-118.13",
+	"timeZone" : "-08:00"
+}]
+      end
+
       geolocation = GeoIp.geolocation(IP_GOOGLE_US, :precision => :city)
       geolocation[:country_code].should == 'US'
       geolocation[:country_name].should == 'UNITED STATES'
@@ -53,24 +136,60 @@ describe 'GeoIp' do
 
   context 'country' do
     it 'should return the correct country for a public ip address' do
+      stub_geolocation(IP_GOOGLE_US, :precision => :country) do
+%[{
+	"statusCode" : "OK",
+	"statusMessage" : "",
+	"ipAddress" : "209.85.227.104",
+	"countryCode" : "US",
+	"countryName" : "UNITED STATES"
+}]
+      end
       geolocation = GeoIp.geolocation(IP_GOOGLE_US, :precision => :country)
       geolocation[:country_code].should == 'US'
       geolocation[:country_name].should == 'UNITED STATES'
     end
 
     it 'should return nothing country for a private ip address' do
+      stub_geolocation(IP_PRIVATE, :precision => :country) do
+%[{
+	"statusCode" : "OK",
+	"statusMessage" : "",
+	"ipAddress" : "10.0.0.1",
+	"countryCode" : "-",
+	"countryName" : "-"
+}]
+      end
       geolocation = GeoIp.geolocation(IP_PRIVATE, :precision => :country)
       geolocation[:country_code].should == '-'
       geolocation[:country_name].should == '-'
     end
 
     it 'should return nothing country for localhost ip address' do
+      stub_geolocation(IP_LOCAL, :precision => :country) do
+%[{
+	"statusCode" : "OK",
+	"statusMessage" : "",
+	"ipAddress" : "127.0.0.1",
+	"countryCode" : "-",
+	"countryName" : "-"
+}]
+      end
       geolocation = GeoIp.geolocation(IP_LOCAL, :precision => :country)
       geolocation[:country_code].should == '-'
       geolocation[:country_name].should == '-'
     end
 
     it 'should not return the city for a public ip address' do
+      stub_geolocation(IP_GOOGLE_US, :precision => :country) do
+%[{
+	"statusCode" : "OK",
+	"statusMessage" : "",
+	"ipAddress" : "209.85.227.104",
+	"countryCode" : "US",
+	"countryName" : "UNITED STATES"
+}]
+      end
       geolocation = GeoIp.geolocation(IP_GOOGLE_US, :precision => :country)
       geolocation[:country_code].should == 'US'
       geolocation[:country_name].should == 'UNITED STATES'
@@ -80,23 +199,96 @@ describe 'GeoIp' do
 
   context 'timezone' do
     it 'should return the correct timezone information for a public ip address' do
+      stub_geolocation(IP_GOOGLE_US, :timezone => true) do
+%[{
+	"statusCode" : "OK",
+	"statusMessage" : "",
+	"ipAddress" : "209.85.227.104",
+	"countryCode" : "US",
+	"countryName" : "UNITED STATES",
+	"regionName" : "CALIFORNIA",
+	"cityName" : "MONTEREY PARK",
+	"zipCode" : "91754",
+	"latitude" : "34.0505",
+	"longitude" : "-118.13",
+	"timeZone" : "-08:00"
+}]
+      end
       geolocation = GeoIp.geolocation(IP_GOOGLE_US, :timezone => true)
       geolocation[:timezone].should == '-08:00' # This one is likely to break when dst changes.
     end
 
     it 'should not return the timezone information when explicitly not requesting it' do
+      stub_geolocation(IP_GOOGLE_US, :timezone => false) do
+%[{
+	"statusCode" : "OK",
+	"statusMessage" : "",
+	"ipAddress" : "209.85.227.104",
+	"countryCode" : "US",
+	"countryName" : "UNITED STATES",
+	"regionName" : "CALIFORNIA",
+	"cityName" : "MONTEREY PARK",
+	"zipCode" : "91754",
+	"latitude" : "34.0505",
+	"longitude" : "-118.13",
+	"timeZone" : "-08:00"
+}]
+      end
       geolocation = GeoIp.geolocation(IP_GOOGLE_US, :timezone => false)
       geolocation[:timezone].should be_nil
     end
 
     it 'should not return the timezone information when not requesting it' do
+      stub_geolocation(IP_GOOGLE_US) do
+%[{
+	"statusCode" : "OK",
+	"statusMessage" : "",
+	"ipAddress" : "209.85.227.104",
+	"countryCode" : "US",
+	"countryName" : "UNITED STATES",
+	"regionName" : "CALIFORNIA",
+	"cityName" : "MONTEREY PARK",
+	"zipCode" : "91754",
+	"latitude" : "34.0505",
+	"longitude" : "-118.13",
+	"timeZone" : "-08:00"
+}]
+      end
       geolocation = GeoIp.geolocation(IP_GOOGLE_US)
       geolocation[:timezone].should be_nil
     end
 
     it 'should not return the timezone information when country precision is selected' do
+      stub_geolocation(IP_GOOGLE_US, :precision => :country, :timezone => true) do
+%[{
+	"statusCode" : "OK",
+	"statusMessage" : "",
+	"ipAddress" : "209.85.227.104",
+	"countryCode" : "US",
+	"countryName" : "UNITED STATES",
+	"regionName" : "CALIFORNIA",
+	"cityName" : "MONTEREY PARK",
+	"zipCode" : "91754",
+	"latitude" : "34.0505",
+	"longitude" : "-118.13",
+	"timeZone" : "-08:00"
+}]
+      end
       geolocation = GeoIp.geolocation(IP_GOOGLE_US, :precision => :country, :timezone => true)
       geolocation[:timezone].should be_nil
+    end
+  end
+
+  context "timeout" do
+    it 'should trigger timeout when the request is taking too long' do
+      stub_request(:get, GeoIp.lookup_url(IP_GOOGLE_US)).to_timeout
+      lambda { GeoIp.geolocation(IP_GOOGLE_US) }.should raise_exception("Request Timeout")
+    end
+
+    it 'should trigger fallback timeout when RestClient is taking too long to send the request', :focus => true do
+      GeoIp.fallback_timeout = 1
+      RestClient::Request.stub(:execute) { sleep 1 }
+      lambda { GeoIp.geolocation(IP_GOOGLE_US) }.should raise_exception(Timeout::Error)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 require 'rubygems'
 require 'bundler/setup'
 require 'geo_ip'
+require 'webmock/rspec'


### PR DESCRIPTION
... to enforce timeout if caused by bad internet connection or slow or invalid DNS lookup. Tests included.

Added WebMock to tests to have reliable tests.

You can turn WebMock off by change the USE_WEBMOCK constant before executing tests.

Related: #4
